### PR TITLE
Update OpenPeripheralIntegration.cfg

### DIFF
--- a/config/OpenPeripheralIntegration.cfg
+++ b/config/OpenPeripheralIntegration.cfg
@@ -6,7 +6,7 @@ modules {
     B:buildcraft-api-tilenentity=true
     B:buildcraft-api-transport=true
     B:cofh-api-energy=true
-    B:cofh-api-inventory=true
+    B:cofh-api-inventory=false
     B:cofh-api-item=true
     B:cofh-api-tileentity=true
     B:cofh-api-transport=true
@@ -26,8 +26,8 @@ modules {
     B:thermalexpansion-mod=true
     B:tmechworks-mod=true
     B:vanilla=true
-    B:vanilla-inventory=true
-    B:vanilla-inventory-manipulation=true
+    B:vanilla-inventory=false
+    B:vanilla-inventory-manipulation=false
 }
 
 


### PR DESCRIPTION
These three drivers added by OpenPeripheral Integration make three items in OpenComputers entirely useless, them (and everything else in this mod) mainly being designed for use with ComputerCraft where they make sense to have. With these turned on, the Inventory Controller Upgrade, the Database Upgrade and Transposers make no sense to have since the inventory drivers added by OpenPeripheral allow doing almost the same things entirely for free. I propose disabling them and instead making OpenComputers items useful like they should be.

All other drivers added by OpenPeripheral are just fine.
