### PR TITLE
Made Disassembler always return everything and not have a chance of breaking

### DIFF
--- a/config/OpenComputers.cfg
+++ b/config/OpenComputers.cfg
@@ -629,7 +629,7 @@ opencomputers {
     # applies *per extracted item*. For example, if an item was crafted from
     # three other items and gets disassembled, each of those three items has
     # this chance of breaking in the process.
-    disassemblerBreakChance=0.05
+    disassemblerBreakChance=0.0
 
     # Names of items / blocks that are blacklisted. Recipes containing these
     # as inputs will be ignored by the disassembler.


### PR DESCRIPTION
I guess this fits well into this pack. No loss when disassembling OpenComputers items or blocks.
