### PR TITLE
Create Mekanism.zs

### DIFF
--- a/scripts/Mekanism.zs
+++ b/scripts/Mekanism.zs
@@ -1,0 +1,6 @@
+# Make stuff from Mekanism play better with others
+
+# Makes Mekanism salt a valid stand-in for Harvestcraft salt
+val ODfoodSalt = <ore:foodSalt>;
+val itemMekSalt = <Mekanism:Salt>;
+ODfoodSalt.add(itemMekSalt);


### PR DESCRIPTION
Add Mekanism salt to foodSalt ore dictionary. Since it doesn't seem you can create Pam's salt in this pack, and Mekansim salt is used in worldgen, this tweak is necessary for some Harvestcraft recipes such as "Sweet Pickle."
